### PR TITLE
Add 503 error handling and fix test

### DIFF
--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -38,6 +38,8 @@ module.exports = class Request
       else if response.statusCode is 401
         {challengenodeid, challengesessionid} = response.headers
         done err, {challenge: body.challenge, challengeNodeId: challengenodeid, challengeSessionId: challengesessionid}
+      else if response.statusCode is 429
+        done new Error "API requests have exceeded the throttling limit."
       else
         return done err, body if body
         done err, response.statusCode

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -33,10 +33,14 @@ module.exports = class Request
     requestMethod params, (err, response, body) ->
       return done err if err
       debug "#{params.method} #{response.request.uri.path} - #{response.statusCode} #{response.statusMessage}"
-      return done err, response.statusCode if response.statusCode is 200 and not body
-      return done err, body unless response.statusCode is 401
-      {challengenodeid, challengesessionid} = response.headers
-      done err, {challenge: body.challenge, challengeNodeId: challengenodeid, challengeSessionId: challengesessionid}
+      if response.statusCode is 503
+        return done new Error "#{response.body.errorInfo[0].errorCode} - #{response.body.errorInfo[0].errorMessage}"
+      else if response.statusCode is 401
+        {challengenodeid, challengesessionid} = response.headers
+        done err, {challenge: body.challenge, challengeNodeId: challengenodeid, challengeSessionId: challengesessionid}
+      else
+        return done err, body if body
+        done err, response.statusCode
 
   get: (url, body, done) ->
     @_params "GET", url, (err, params) =>

--- a/test/api.coffee
+++ b/test/api.coffee
@@ -67,6 +67,27 @@ describe "Intuit Client", ->
             assert /Login error/.test err.message
             done null
 
+      describe "Single Factor Authentication With Rate Limiting Error", ->
+        before -> fixture.load "discoverAndAddAccountsRateLimit"
+        it "should return an error with the details", (done) ->
+          loginDetails =
+            credentials:
+              credential: [
+                {
+                  name: "Banking Userid"
+                  value: "bad"
+                }
+
+                {
+                  name: "Banking Password"
+                  value: "go"
+                }
+              ]
+          intuit.discoverAndAddAccounts "userId", 100000, loginDetails, (err, accounts) ->
+            assert err
+            assert /throttling/.test err.message
+            done null
+
       describe "Multi Factor Authentication", ->
         before -> fixture.load "discoverAndAddAccountsMfa"
         before (done) ->

--- a/test/api.coffee
+++ b/test/api.coffee
@@ -28,7 +28,7 @@ describe "Intuit Client", ->
     describe "discoverAndAddAccounts", ->
       describe "Single Factor Authentication", ->
         before -> fixture.load "discoverAndAddAccounts"
-        it "should return newly created accounts", ->
+        it "should return newly created accounts", (done) ->
           loginDetails =
             credentials:
               credential: [
@@ -45,6 +45,27 @@ describe "Intuit Client", ->
           intuit.discoverAndAddAccounts "userId", 100000, loginDetails, (err, accounts) ->
             assert.equal accounts.length, 10
             done err
+
+      describe "Single Factor Authentication With Wrong Password", ->
+        before -> fixture.load "discoverAndAddAccountsWrongPassword"
+        it "should return an error with the details", (done) ->
+          loginDetails =
+            credentials:
+              credential: [
+                {
+                  name: "Banking Userid"
+                  value: "bad"
+                }
+
+                {
+                  name: "Banking Password"
+                  value: "go"
+                }
+              ]
+          intuit.discoverAndAddAccounts "userId", 100000, loginDetails, (err, accounts) ->
+            assert err
+            assert /Login error/.test err.message
+            done null
 
       describe "Multi Factor Authentication", ->
         before -> fixture.load "discoverAndAddAccountsMfa"

--- a/test/fixtures/discoverAndAddAccounts.json
+++ b/test/fixtures/discoverAndAddAccounts.json
@@ -1,9 +1,22 @@
 [
   {
     "scope": "https://financialdatafeed.platform.intuit.com:443",
-    "method": "GET",
-    "path": "/v1/accounts/400107846787",
-    "body": "",
+    "method": "POST",
+    "path": "/v1/institutions/100000/logins",
+    "body": {
+      "credentials": {
+        "credential": [
+          {
+            "name": "Banking Userid",
+            "value": "demo"
+          },
+          {
+            "name": "Banking Password",
+            "value": "go"
+          }
+        ]
+      }
+    },
     "status": 200,
     "response": {
       "accounts": [

--- a/test/fixtures/discoverAndAddAccountsRateLimit.json
+++ b/test/fixtures/discoverAndAddAccountsRateLimit.json
@@ -1,0 +1,31 @@
+[
+  {
+    "scope": "https://financialdatafeed.platform.intuit.com:443",
+    "method": "POST",
+    "path": "/v1/institutions/100000/logins",
+    "body": {
+      "credentials": {
+        "credential": [
+          {
+            "name": "Banking Userid",
+            "value": "bad"
+          },
+          {
+            "name": "Banking Password",
+            "value": "go"
+          }
+        ]
+      }
+    },
+    "status": 429,
+    "response": {
+    },
+    "headers": {
+      "date": "Tue, 28 Jul 2015 18:32:49 GMT",
+      "content-type": "text/plain",
+      "content-length": "0",
+      "intuit_tid": "gw-1e6def67-b82b-4317-981c-d2e7bed343c8",
+      "connection": "close"
+    }
+  }
+]

--- a/test/fixtures/discoverAndAddAccountsWrongPassword.json
+++ b/test/fixtures/discoverAndAddAccountsWrongPassword.json
@@ -1,0 +1,39 @@
+[
+  {
+    "scope": "https://financialdatafeed.platform.intuit.com:443",
+    "method": "POST",
+    "path": "/v1/institutions/100000/logins",
+    "body": {
+      "credentials": {
+        "credential": [
+          {
+            "name": "Banking Userid",
+            "value": "bad"
+          },
+          {
+            "name": "Banking Password",
+            "value": "go"
+          }
+        ]
+      }
+    },
+    "status": 503,
+    "response": {
+    "errorInfo": [
+      {
+        "errorType": "WARNING",
+        "errorCode": "103",
+        "correlationId": "gw-5204d370-3fe0-47d1-acd2-eaf176357ea1",
+        "errorMessage": "Login error. Error on logon"
+      }
+    ]
+  },
+    "headers": {
+      "date": "Tue, 28 Jul 2015 18:32:49 GMT",
+      "content-type": "text/plain",
+      "content-length": "0",
+      "intuit_tid": "gw-1e6def67-b82b-4317-981c-d2e7bed343c8",
+      "connection": "close"
+    }
+  }
+]

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -84,6 +84,10 @@ fixtures =
     oauth()
     load "discoverAndAddAccountsWrongPassword"
 
+  discoverAndAddAccountsRateLimit: ->
+    oauth()
+    load "discoverAndAddAccountsRateLimit"
+
   handleMfa: ->
     oauth()
     load "handleMfa"

--- a/test/fixtures/index.coffee
+++ b/test/fixtures/index.coffee
@@ -80,6 +80,10 @@ fixtures =
     oauth()
     load "discoverAndAddAccountsMfa"
 
+  discoverAndAddAccountsWrongPassword: ->
+    oauth()
+    load "discoverAndAddAccountsWrongPassword"
+
   handleMfa: ->
     oauth()
     load "handleMfa"


### PR DESCRIPTION
Intuit uses this status code for a variety of login problems, primarily wrong bank credentials. Return a proper error when this is the case.